### PR TITLE
Added 'Print Past Purchases' function and feature, fixed names being added to currentUser

### DIFF
--- a/FinalProject/Final.cpp
+++ b/FinalProject/Final.cpp
@@ -17,15 +17,16 @@ int menu()
 	cout << "3. Buy a Product" << endl;
 	cout << "4. Net profit"	<< endl;
 	cout << "5. Add Money to Wallet"	<< endl;
-	cout << "6. Quit" << endl; 
-	
+	cout << "6. Print Past Purchases" << endl;
+	cout << "7. Quit" << endl;
+
 	//converting the users choice
 	int choice;
 	string choiceS;
 	getline(cin,choiceS);
 	stringstream choiceConvert(choiceS);
 	choiceConvert >> choice;
-	
+
 	return choice;
 }
 
@@ -35,18 +36,18 @@ void newSettings(market * coinMarket)
 	string settings = "settings.txt";
 	ifstream settingsFile;
 	settingsFile.open(settings.c_str());
-	
-	//If file opening doesn't work this happens 
+
+	//If file opening doesn't work this happens
 	if(!settingsFile)
 	{
 		cout << "settings opening unsuccessful" << endl;
 	}
-	//parsing the file 
-	
+	//parsing the file
+
 	//initalizing the variables
 	//____s versions of names is where the getline of the variable is stored before being converted
 	double decay;
-	string decayS;	
+	string decayS;
 	double decayBase;
 	string decayBaseS;
 	bool recency;
@@ -57,12 +58,12 @@ void newSettings(market * coinMarket)
 	string maxPS;
 	double postMultiplier;
 	string postMultiplierS;
-	
+
 	//storing the settigns in the string versions of the settings
 	getline(settingsFile,decayS);
 	// the : version of the getline storage gets rid of all of the
 	//     text before the : without changing the value
-	getline(settingsFile,decayS,':');  
+	getline(settingsFile,decayS,':');
 	getline(settingsFile,decayS);
 	getline(settingsFile,decayBaseS,':');
 	getline(settingsFile,decayBaseS);
@@ -74,7 +75,7 @@ void newSettings(market * coinMarket)
 	getline(settingsFile,maxPS);
 	getline(settingsFile,postMultiplierS,':');
 	getline(settingsFile,postMultiplierS);
-	
+
 	//Converting all of the strings to the appropriate type
 	stringstream decayConvert(decayS);
 	decayConvert >> decay;
@@ -88,10 +89,10 @@ void newSettings(market * coinMarket)
 	maxPConvert >> maxP;
 	stringstream postMultiplierConvert(postMultiplierS);
 	postMultiplierConvert >> postMultiplier;
-	
+
 	//Setting the settings values
 	coinMarket->addSettings(decay,decayBase,recency,max,maxP,postMultiplier);
-	
+
 }
 
 void newProducts(market * coinMarket)
@@ -100,8 +101,8 @@ void newProducts(market * coinMarket)
 	string products = "Products.txt";
 	ifstream productsFile;
 	productsFile.open(products.c_str());
-	
-	//If file opening doesn't work this happens 
+
+	//If file opening doesn't work this happens
 	if(!productsFile)
 	{
 		cout << "file opening unsuccessful " << endl;
@@ -118,23 +119,23 @@ void newProducts(market * coinMarket)
 		string priceS;
 		double cost;
 		string costS;
-		
+
 		//parsing the line
 		getline(productsFile,name,',');
 		getline(productsFile,quantityS,' ');
 		getline(productsFile,priceS,' ');
 		getline(productsFile,costS);
-		
+
 		//converting the varibles
 		stringstream quantityConvert(quantityS);
 		quantityConvert >> quantity;
-		
+
 		stringstream priceConvert(priceS);
 		priceConvert >> price;
-		
+
 		stringstream costConvert(costS);
 		costConvert >> cost;
-		
+
 		//giving it to the addProduct method
 		if(name != "")
 		{
@@ -149,15 +150,16 @@ void newUser(market *coinMarket)
 	string userName;
 	//password is unused scrapped idea
 	string password = "password";
-	
+
 	//getting wallet info
-	getline(cin,password);	cout << "How much is in your wallet? " << endl;
+	getline(cin,userName);
+	cout << "How much is in your wallet? " << endl;
 	double wallet;
 	string walletS;
 	getline(cin,walletS);
 	stringstream walletConvert(walletS);
 	walletConvert >> wallet;
-	
+
 	//runnign the addUser method multiple users scrapped
 	coinMarket->addNewUser(userName,password, wallet);
 }
@@ -168,7 +170,6 @@ int main(int argc, char **argv)
 	newSettings(coinMarket);
 	newProducts(coinMarket);
 	newUser(coinMarket);
-	
 	//menu loop
 	bool interfaceKill = 0;
 	while(!interfaceKill)
@@ -184,7 +185,7 @@ int main(int argc, char **argv)
 			}
 			case 2:
 			{
-				//giving the some past data about the time 
+				//giving the some past data about the time
 				coinMarket->timeStats();
 				break;
 			}
@@ -210,15 +211,20 @@ int main(int argc, char **argv)
 				break;
 			}
 			case 6:
+            {
+                coinMarket->pastPurchases();
+                break;
+            }
+			case 7:
 			{
 				//ending the program
 				interfaceKill = 1;
 				break;
 			}
 		}
-		
+
 	}
-	
+
 	return 0;
-	
+
 }

--- a/FinalProject/market.cpp
+++ b/FinalProject/market.cpp
@@ -14,7 +14,7 @@ market::market()
 market::~market()
 {
 }
-//unused method to check of the numbers a user inputs are double but all the user inputs ended up being 
+//unused method to check of the numbers a user inputs are double but all the user inputs ended up being
 //	getline() with doubles so there ws no longer a point to the method
 int market::checkNumber(std::string number)
 {
@@ -45,7 +45,7 @@ int market::checkNumber(std::string number)
 		std::stringstream convert(number);
 		convert >> nonSNumber;
 	}
-	/*return codes 
+	/*return codes
 	 * -1 not a number
 	 * non negative number the number is actual number
 	*/
@@ -56,7 +56,7 @@ void market::addProducts(std::string name,int quantity, double price, double cos
 {
 	//allocating memory for a new product
 	product *newProduct = new product(name,quantity,price,cost,time(&(settingsStorage.startTime)));
-	
+
 	//adding a product to a tree
 	product *temp = root;
 	if(root == NULL)
@@ -66,7 +66,7 @@ void market::addProducts(std::string name,int quantity, double price, double cos
 	else
 	{
 	//traversing the tree
-		
+
 		//while loop ender
 		bool kill = 0;
 		while(!kill)
@@ -114,19 +114,19 @@ void market::addSettings(double decay, double decayBase, bool recency, bool max,
 	settingsStorage.recencyDetection = recency;
 	settingsStorage.maxPrice = max;
 	settingsStorage.maxPriceMultiplier = maxP;
-	
+
 	//reason for method
 	time_t startTime;
 	settingsStorage.startTime = time(&startTime);
 	lastTimeCheck = startTime;
-	
+
 	settingsStorage.postBuyMultiplier = postMultiplier;
 }
 
 void market::buyProduct(std::string name)
 {
 	product *temp = findProduct(name);
-	
+
 	//if product found
 	if(temp != NULL)
 	{
@@ -136,23 +136,23 @@ void market::buyProduct(std::string name)
 			//if the user can afford it
 			if(currentUser->wallet > temp->price)
 			{
-				//reduced the nventory by one
+				//reduced the inventory by one
 				(temp->quantity)--;
-				
+
 				//pay for the product
 				currentUser->wallet = currentUser->wallet - temp->price;
 				//for use in storage after the price is changes
 				double salePrice = temp->price;
 				std::cout << "You have " << currentUser->wallet << " dollars left in your wallet." << std::endl;
-				
+
 				//don't remember exactly why this is here but the idea seems important
 				if(temp->base < temp->price * (pow(settingsStorage.decayRateBase,settingsStorage.decayRate * (time(&settingsStorage.startTime) - temp->lastSold))))
 				{
 					temp->price = temp->price * (pow(settingsStorage.decayRateBase,settingsStorage.decayRate * (time(&settingsStorage.startTime) - temp->lastSold)));
 				}
-				
+
 				temp->lastSold = time(&settingsStorage.startTime);
-				
+
 				//stroing the purchase information every where (very memory inefficient)
 				purchase *newPurchase = new purchase(time(&settingsStorage.startTime),currentUser,temp,salePrice);
 				temp->price = temp->price*(settingsStorage.postBuyMultiplier);
@@ -193,7 +193,7 @@ void market::printProducts(product *node)
 			temp->price = temp->price * (pow(settingsStorage.decayRateBase,settingsStorage.decayRate * (time(&settingsStorage.startTime) - temp->lastSold)));
 		}
 		temp->lastSold = time(&settingsStorage.startTime);
-		std::cout << "Name: "<< temp->name  << std::endl << "  Price: "<< temp->price << std::endl << "  Quantity: " << temp->quantity << std::endl; 
+		std::cout << "Name: "<< temp->name  << std::endl << "  Price: "<< temp->price << std::endl << "  Quantity: " << temp->quantity << std::endl;
 	}
 	if(temp->right != NULL)
 	{
@@ -254,8 +254,8 @@ product * market::findProduct(std::string name)
 
 void market::timeStats()
 {
-	//printing out some user info 
-	std::cout << "Current time: " << time(&settingsStorage.startTime) <<std::endl;  
+	//printing out some user info
+	std::cout << "Current time: " << time(&settingsStorage.startTime) <<std::endl;
 	std::cout << "Last time check was  " << time(&settingsStorage.startTime) - lastTimeCheck << " seconds ago" <<std::endl;
 	lastTimeCheck = time(&settingsStorage.startTime);
 }
@@ -274,7 +274,7 @@ void market::addNewUser(std::string name, std::string password, double wallet)
 
 void market::printProfit(product * node)
 {
-	//same basic idea as the tree print 
+	//same basic idea as the tree print
 	product *temp = node;
 	if(temp->left != NULL)
 	{
@@ -287,7 +287,7 @@ void market::printProfit(product * node)
 			temp->price = temp->price * (pow(settingsStorage.decayRateBase,settingsStorage.decayRate * (time(&settingsStorage.startTime) - temp->lastSold)));
 		}
 		temp->lastSold = time(&settingsStorage.startTime);
-		std::cout << "Name: "<< temp->name  << std::endl << "Profit: "<< temp->profit << std::endl; 
+		std::cout << "Name: "<< temp->name  << std::endl << "Profit: "<< temp->profit << std::endl;
 	}
 	if(temp->right != NULL)
 	{
@@ -299,8 +299,8 @@ void market::totalProfit()
 	totalProfit(blockChain);
 }
 void market::totalProfit(std::vector<purchaseBlockChain*> blockChain)
-{	
-	//runs though the purchase block chain and adds the net profit 
+{
+	//runs though the purchase block chain and adds the net profit
 	int blockChainSize = blockChain.size();
 	for(int blockChainIndex = 0; blockChainIndex < blockChainSize; blockChainIndex++)
 	{
@@ -323,4 +323,23 @@ void market::addMoney()
 	std::stringstream convertMoney(moneyS);
 	convertMoney >> money;
 	currentUser->wallet = currentUser->wallet + money;
+}
+
+void market::pastPurchases()
+{
+	pastPurchases(blockChain);
+}
+void market::pastPurchases(std::vector<purchaseBlockChain*> blockChain)
+{
+	//runs though the purchase block chain prints all past purchases
+	int blockChainSize = blockChain.size();
+	for(int blockChainIndex = 0; blockChainIndex < blockChainSize; blockChainIndex++)
+	{
+		//stores profit from each  product in its spot in the tree
+		purchase *currentPurchase = blockChain[blockChainIndex]->purchaseEvent;
+		std::cout<<"Coin:"<<currentPurchase->item->name<<std::endl;
+		std::cout<<"  Cost:"<<currentPurchase->cost<<std::endl;
+		std::cout<<"  Name:"<<currentPurchase->buyer->name<<std::endl;
+		std::cout<<"  Time:"<<currentPurchase->time<<std::endl<<std::endl;
+	}
 }

--- a/FinalProject/market.h
+++ b/FinalProject/market.h
@@ -11,7 +11,7 @@ struct settings{
 	bool maxPrice;
 	double maxPriceMultiplier;
 	time_t startTime;
-	
+
 };
 
 struct product{
@@ -27,7 +27,7 @@ struct product{
 	std::vector<int> soldChain;
 	product *left = NULL;
 	product *right = NULL;
-	
+
 	product(){};
 
     product(std::string in_name, int in_quantity, double in_price, double in_cost, time_t start_time)
@@ -49,14 +49,14 @@ struct userInfo{
 	std::string password;
 	double wallet;
 	std::vector<personalPurchase*> purchases;
-	
+
 	userInfo(std::string in_name, std::string in_password, double in_wallet)
 	{
 		name = in_name;
 		password = in_password;
 		wallet = in_wallet;
 	}
-	
+
 };
 
 struct purchase{
@@ -64,7 +64,7 @@ struct purchase{
 	userInfo *buyer;
 	product *item;
 	double cost;
-	
+
 	purchase(time_t in_time, userInfo *in_buyer, product *in_item,double in_cost)
 	{
 		time = in_time;
@@ -76,7 +76,7 @@ struct purchase{
 
 struct personalPurchase{
 	purchase *purchaseEvent;
-	
+
 	personalPurchase(purchase *in_purchase)
 	{
 		purchaseEvent = in_purchase;
@@ -85,7 +85,7 @@ struct personalPurchase{
 
 struct purchaseBlockChain{
 	purchase *purchaseEvent;
-	
+
 	purchaseBlockChain(purchase *in_purchase)
 	{
 		purchaseEvent = in_purchase;
@@ -110,8 +110,9 @@ class market
 		void totalProfit();
 		void timeStats();
 		void addMoney();
+		void pastPurchases();
 
-		
+
 	protected:
 	private:
 		settings settingsStorage;
@@ -127,5 +128,6 @@ class market
 		userInfo *currentUser = NULL;
 		void totalProfit(std::vector<purchaseBlockChain*> blockChain);
 		void printProfit(product * node);
+		void pastPurchases(std::vector<purchaseBlockChain*> blockChain);
 };
 


### PR DESCRIPTION
Print Past Purchases added:
- Displays coin, cost of purchase, name of user who made purchase, and time of purchase
- Runs though the purchase block chain and prints all past purchases

Fixed names being added to currentUser
- Fixes #2 
- Looks like it was accidentally storing the name into password string instead of name string.
